### PR TITLE
Add output-dir and nodes flag to the output command

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Example GitHub action usage
 Use the **output** command to download the outputs of your particular workflow execution(s) to your local environment.
 
 ```
-trickest output --workflow <workflow_name> --space <space_name> [--config <config_file_path>] [--runs <number>]
+trickest output --workflow <workflow_name> --space <space_name> [--nodes <comma_separated_list_of_nodes>] [--config <config_file_path>] [--runs <number>] [--output-dir <output_path_directory>]
 ```
 | Flag       | Type    | Default | Description                                                                                                                        |
 | ---------- | ------  | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -224,6 +224,8 @@ trickest output --workflow <workflow_name> --space <space_name> [--config <confi
 | --config   | file    | /       | YAML file for run configuration                                                                                                    |
 | --run      | string  | /       | Download output data of a specific run                                                                                             |
 | --runs     | integer | 1       | The number of executions to be downloaded sorted by newest |
+| --output-dir     | string | /       | Path to directory which should be used to store outputs |
+| --nodes     | string | /       | A comma separated list of nodes whose outputs should be downloaded |
 
 
 ## Output Structure

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -38,6 +38,8 @@ var (
 	allRuns      bool
 	numberOfRuns int
 	runID        string
+	outputDir    string
+	nodesFlag    string
 )
 
 // OutputCmd represents the download command
@@ -59,6 +61,11 @@ The YAML config file should be formatted like:
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		nodes := make(map[string]NodeInfo, 0)
+		if nodesFlag != "" {
+			for _, node := range strings.Split(nodesFlag, ",") {
+				nodes[strings.ReplaceAll(node, "/", "-")] = NodeInfo{ToFetch: true, Found: false}
+			}
+		}
 
 		path := util.FormatPath()
 		if path == "" {
@@ -147,6 +154,9 @@ The YAML config file should be formatted like:
 			return
 		}
 
+		if outputDir != "" {
+			path = outputDir
+		}
 		for _, run := range runs {
 			if run.Status == "SCHEDULED" {
 				continue
@@ -161,6 +171,8 @@ func init() {
 	OutputCmd.Flags().BoolVar(&allRuns, "all", false, "Download output data for all runs")
 	OutputCmd.Flags().IntVar(&numberOfRuns, "runs", 1, "Number of recent runs which outputs should be downloaded")
 	OutputCmd.Flags().StringVar(&runID, "run", "", "Download output data of a specific run")
+	OutputCmd.Flags().StringVar(&outputDir, "output-dir", "", "Path to directory which should be used to store outputs")
+	OutputCmd.Flags().StringVar(&nodesFlag, "nodes", "", "A comma separated list of nodes which outputs should be downloaded")
 }
 
 func DownloadRunOutput(run *types.Run, nodes map[string]NodeInfo, version *types.WorkflowVersionDetailed, destinationPath string) {

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -172,7 +172,7 @@ func init() {
 	OutputCmd.Flags().IntVar(&numberOfRuns, "runs", 1, "Number of recent runs which outputs should be downloaded")
 	OutputCmd.Flags().StringVar(&runID, "run", "", "Download output data of a specific run")
 	OutputCmd.Flags().StringVar(&outputDir, "output-dir", "", "Path to directory which should be used to store outputs")
-	OutputCmd.Flags().StringVar(&nodesFlag, "nodes", "", "A comma separated list of nodes which outputs should be downloaded")
+	OutputCmd.Flags().StringVar(&nodesFlag, "nodes", "", "A comma-separated list of nodes whose outputs should be downloaded")
 }
 
 func DownloadRunOutput(run *types.Run, nodes map[string]NodeInfo, version *types.WorkflowVersionDetailed, destinationPath string) {


### PR DESCRIPTION
- `output-dir` is a path to the directory where outputs will be stored
- `nodes` is a comma-separated list of nodes which outputs should be downloaded