### PR TITLE
Check for arguments before applying URL formatting

### DIFF
--- a/client/request/request.go
+++ b/client/request/request.go
@@ -99,7 +99,10 @@ func (r *Request) Verb(verb string) *Request {
 }
 
 func (r *Request) DoF(url string, v ...interface{}) *Response {
-	return r.Do(fmt.Sprintf(url, v...))
+	if len(v) > 0 {
+		url = fmt.Sprintf(url, v...)
+	}
+	return r.Do(url)
 }
 
 func (r *Request) Do(url string) *Response {


### PR DESCRIPTION
This fixes a bug where URL-encoded characters were incorrectly parsed as format string directives.