### PR TITLE
Add URL input for specifying platform objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ trickest list
 
 #### Spaces
 
-Use the **list** command with the **--space** flag to list the content of your particular space; its projects and workflows, and their descriptions.
+Use the **list** command with the **--space** or **--url** flag to list the content of your particular space; its projects and workflows, and their descriptions.
 
 ```
 trickest list --space <space_name>
@@ -73,22 +73,24 @@ trickest list --space <space_name>
 |---------|--------|---------|-------------------------------------|
 | --space | string | /       | The name of the space to be listed  |
 | --json  | boolean| /       | Display output in JSON format       |
+| --url   | string | /       | URL for referencing a space         |
 
 
 
 #### Projects   
 
-Use the **list** command with the **--project** option to list the content of your particular project; its workflows, along with their descriptions.
+Use the **list** command with the **--project** or **--url** option to list the content of your particular project; its workflows, along with their descriptions.
 
 ```
 trickest list --project <project_name> --space <space_name>
 ```
 
-| Flag      | Type   | Default | Description                                        |
-|-----------|--------|---------|----------------------------------------------------|
-| --project | string | /       | The name of the project to be listed.              |
-| --space   | string | /       | The name of the space to which the project belongs |
-| --json    | boolean  | /     | Display output in JSON format                      |
+| Flag      | Type    | Default | Description                                        |
+|-----------|---------|---------|----------------------------------------------------|
+| --project | string  | /       | The name of the project to be listed.              |
+| --space   | string  | /       | The name of the space to which the project belongs |
+| --json    | boolean | /       | Display output in JSON format                      |
+| --url     | string  | /       | URL for referencing a space                        |
 
 
 ##### Note: When passing values that have spaces in their names (e.g. "Alpine Testing"), they need to be double-quoted.
@@ -109,6 +111,7 @@ trickest get --workflow <workflow_name> --space <space_name> [--watch]
 | --run       | string   | /       | Get the status of a specific run                                       |
 | --watch     | boolean  | /       | Option to track execution status in case workflow is in running state  |
 | --json      | boolean  | /       | Display output in JSON format                                          |
+| --url       | string   | /       | URL for referencing a space                                            |
 
 ##### If the supplied workflow has a running execution, you can jump in and watch it running with the `--watch` flag!
 
@@ -192,6 +195,7 @@ trickest output --workflow <workflow_name> --space <space_name> [--nodes <comma_
 | ---------- | ------  | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | --workflow | string  | /       | The name of the workflow.                                                                                                          |
 | --space    | string  | /       | The name of the space to which workflow belongs                                                                                    |
+| --url      | string  | /       | URL for referencing a space                                                                                                        |
 | --config   | file    | /       | YAML file for run configuration                                                                                                    |
 | --run      | string  | /       | Download output data of a specific run                                                                                             |
 | --runs     | integer | 1       | The number of executions to be downloaded sorted by newest |

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/trickest/trickest-cli/client/request"
 	"github.com/trickest/trickest-cli/cmd/delete"
-	"github.com/trickest/trickest-cli/cmd/list"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
 
@@ -85,7 +84,7 @@ func createSpace(name string, description string) {
 }
 
 func CreateProject(name string, description string, spaceName string) *types.Project {
-	space := list.GetSpaceByName(spaceName)
+	space := util.GetSpaceByName(spaceName)
 	if space == nil {
 		fmt.Println("The space \"" + spaceName + "\" doesn't exist. Would you like to create it? (Y/N)")
 		var answer string
@@ -153,7 +152,7 @@ func CreateWorkflow(name, description string, spaceID, projectID uuid.UUID, dele
 		workflow.ProjectID = &projectID
 	}
 
-	workflows := list.GetWorkflows(projectID, spaceID, name, false)
+	workflows := util.GetWorkflows(projectID, spaceID, name, false)
 	if workflows != nil {
 		for _, wf := range workflows {
 			if wf.Name == name {

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/trickest/trickest-cli/client/request"
-	"github.com/trickest/trickest-cli/cmd/list"
 	"github.com/trickest/trickest-cli/util"
 
 	"github.com/spf13/cobra"
@@ -20,21 +18,7 @@ var DeleteCmd = &cobra.Command{
 	Short: "Deletes an object on the Trickest platform",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		path := util.FormatPath()
-		if path == "" {
-			if len(args) == 0 {
-				fmt.Println("You must specify the path of the object to be deleted!")
-				return
-			}
-			path = strings.Trim(args[0], "/")
-		} else {
-			if len(args) > 0 {
-				fmt.Println("Please use either path or flag syntax for the platform objects.")
-				return
-			}
-		}
-
-		space, project, workflow, found := list.ResolveObjectPath(path, false, util.WorkflowName == "")
+		space, project, workflow, found := util.GetObjects(args)
 		if !found {
 			return
 		}
@@ -51,7 +35,7 @@ var DeleteCmd = &cobra.Command{
 
 func deleteSpace(name string, id uuid.UUID) {
 	if id == uuid.Nil {
-		space := list.GetSpaceByName(name)
+		space := util.GetSpaceByName(name)
 		if space == nil {
 			fmt.Println("Couldn't find space named " + name + "!")
 			os.Exit(0)

--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -175,7 +175,7 @@ func readWorkflowYAMLandCreateVersion(fileName string, workflowName string, obje
 		workflowName = wf.Name
 	}
 
-	space, project, workflow, _ := list.ResolveObjectPath(objectPath, true, false)
+	space, project, workflow, _ := util.ResolveObjectPath(objectPath, true, false)
 	if space == nil {
 		fmt.Println("Space " + strings.Split(objectPath, "/")[0] + " doesn't exist!")
 		os.Exit(0)
@@ -922,9 +922,9 @@ func prepareForExec(objectPath string) *types.WorkflowVersionDetailed {
 	var primitiveNodes map[string]*types.PrimitiveNode
 	projectCreated := false
 
-	space, project, workflow, _ := list.ResolveObjectPath(objectPath, false, false)
-	if space == nil {
-		os.Exit(0)
+	space, project, workflow, _ := util.ResolveObjectPath(objectPath, false, false)
+	if workflow == nil {
+		space, project, workflow, _ = util.ResolveObjectURL(util.URL)
 	}
 
 	if workflow != nil && newWorkflowName == "" {
@@ -943,7 +943,7 @@ func prepareForExec(objectPath string) *types.WorkflowVersionDetailed {
 	} else {
 		// Executing from library
 		wfName := pathSplit[len(pathSplit)-1]
-		libraryWorkflows := list.GetWorkflows(uuid.Nil, uuid.Nil, wfName, true)
+		libraryWorkflows := util.GetWorkflows(uuid.Nil, uuid.Nil, wfName, true)
 		if libraryWorkflows != nil && len(libraryWorkflows) > 0 {
 			// Executing from library
 			for _, wf := range libraryWorkflows {
@@ -976,7 +976,7 @@ func prepareForExec(objectPath string) *types.WorkflowVersionDetailed {
 						os.Exit(0)
 					}
 
-					newWorkflow := list.GetWorkflowByID(newWorkflowID)
+					newWorkflow := util.GetWorkflowByID(newWorkflowID)
 					if newWorkflow.Name != newWorkflowName {
 						newWorkflow.Name = newWorkflowName
 						updateWorkflow(newWorkflow, projectCreated)

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/trickest/trickest-cli/cmd/execute"
-	"github.com/trickest/trickest-cli/cmd/list"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
 
@@ -40,21 +39,7 @@ var ExportCmd = &cobra.Command{
 	Short: "Exports a workflow to a YAML file",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		path := util.FormatPath()
-		if path == "" {
-			if len(args) == 0 {
-				fmt.Println("Workflow path must be specified!")
-				return
-			}
-			path = strings.Trim(args[0], "/")
-		} else {
-			if len(args) > 0 {
-				fmt.Println("Please use either path or flag syntax for the platform objects.")
-				return
-			}
-		}
-
-		_, _, workflow, found := list.ResolveObjectPath(path, false, false)
+		_, _, workflow, found := util.GetObjects(args)
 		if !found {
 			return
 		}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/trickest/trickest-cli/cmd/execute"
-	"github.com/trickest/trickest-cli/cmd/list"
 	"github.com/trickest/trickest-cli/cmd/output"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
@@ -29,27 +28,10 @@ var GetCmd = &cobra.Command{
 	Short: "Displays status of a workflow",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		path := util.FormatPath()
-		if path == "" {
-			if len(args) == 0 {
-				fmt.Println("Workflow path must be specified!")
-				return
-			}
-			path = strings.Trim(args[0], "/")
-		} else {
-			if len(args) > 0 {
-				fmt.Println("Please use either path or flag syntax for the platform objects.")
-				return
-			}
-		}
+		_, _, workflow, found := util.GetObjects(args)
 
-		_, _, workflow, found := list.ResolveObjectPath(path, false, false)
-		if !found {
-			return
-		}
-
-		if workflow == nil {
-			fmt.Println("Error: You need to specify the full location of the workflow with the --space and --project flags")
+		if !found || workflow == nil {
+			fmt.Println("Error: Workflow not found")
 			return
 		}
 

--- a/cmd/library/libraryListWorkflows.go
+++ b/cmd/library/libraryListWorkflows.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/trickest/trickest-cli/cmd/list"
 	"github.com/trickest/trickest-cli/types"
+	"github.com/trickest/trickest-cli/util"
 	"github.com/xlab/treeprint"
 )
 
@@ -17,7 +17,7 @@ var libraryListWorkflowsCmd = &cobra.Command{
 	Short: "List workflows from the Trickest library",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		workflows := list.GetWorkflows(uuid.Nil, uuid.Nil, "", true)
+		workflows := util.GetWorkflows(uuid.Nil, uuid.Nil, "", true)
 		if len(workflows) > 0 {
 			printWorkflows(workflows, jsonOutput)
 		} else {

--- a/cmd/library/librarySearch.go
+++ b/cmd/library/librarySearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/trickest/trickest-cli/cmd/list"
+	"github.com/trickest/trickest-cli/util"
 )
 
 // librarySearchCmd represents the librarySearch command
@@ -21,7 +22,7 @@ var librarySearchCmd = &cobra.Command{
 			search = args[0]
 		}
 		tools := list.GetTools(math.MaxInt, search, "")
-		workflows := list.GetWorkflows(uuid.Nil, uuid.Nil, search, true)
+		workflows := util.GetWorkflows(uuid.Nil, uuid.Nil, search, true)
 		if jsonOutput {
 			results := map[string]interface{}{
 				"tools":     tools,

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -8,9 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 
-	"github.com/google/uuid"
 	"github.com/trickest/trickest-cli/client/request"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
@@ -29,38 +27,10 @@ var ListCmd = &cobra.Command{
 	Short: "Lists objects on the Trickest platform",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		path := util.FormatPath()
-		if len(args) == 0 && path == "" {
-			spaces := getSpaces("")
+		space, project, workflow, found := util.GetObjects(args)
 
-			if spaces != nil && len(spaces) > 0 {
-				printSpaces(spaces, jsonOutput)
-			} else {
-				fmt.Println("Couldn't find any spaces!")
-			}
-			return
-		}
-		if path == "" {
-			path = strings.Trim(args[0], "/")
-		} else {
-			if len(args) > 0 {
-				fmt.Println("Please use either path or flag syntax for the platform objects.")
-				return
-			}
-		}
-
-		var (
-			space    *types.SpaceDetailed
-			project  *types.Project
-			workflow *types.Workflow
-			found    bool
-		)
-		if util.WorkflowName == "" {
-			space, project, workflow, found = ResolveObjectPath(path, false, true)
-		} else {
-			space, project, workflow, found = ResolveObjectPath(path, false, false)
-		}
 		if !found {
+			fmt.Println("Error: Workflow not found")
 			return
 		}
 
@@ -134,7 +104,7 @@ func printProject(project types.Project, jsonOutput bool) {
 				}
 			}
 		}
-
+		output = tree.String()
 	}
 
 	fmt.Println(output)
@@ -203,216 +173,6 @@ func printSpaces(spaces []types.Space, jsonOutput bool) {
 	}
 
 	fmt.Println(output)
-}
-
-func getSpaces(name string) []types.Space {
-	urlReq := "spaces/?vault=" + util.GetVault().String()
-	urlReq += "&page_size=" + strconv.Itoa(math.MaxInt)
-
-	if name != "" {
-		urlReq += "&name=" + url.QueryEscape(name)
-	}
-
-	resp := request.Trickest.Get().DoF(urlReq)
-	if resp == nil {
-		fmt.Println("Error: Couldn't get spaces!")
-		os.Exit(0)
-	}
-
-	if resp.Status() != http.StatusOK {
-		request.ProcessUnexpectedResponse(resp)
-	}
-
-	var spaces types.Spaces
-	err := json.Unmarshal(resp.Body(), &spaces)
-	if err != nil {
-		fmt.Println("Error: Couldn't unmarshal spaces response!")
-		os.Exit(0)
-	}
-
-	return spaces.Results
-}
-
-func GetSpaceByName(name string) *types.SpaceDetailed {
-	spaces := getSpaces(name)
-	if spaces == nil || len(spaces) == 0 {
-		return nil
-	}
-
-	return getSpaceByID(spaces[0].ID)
-}
-
-func getSpaceByID(id uuid.UUID) *types.SpaceDetailed {
-	resp := request.Trickest.Get().DoF("spaces/%s/", id.String())
-	if resp == nil {
-		fmt.Println("Error: Couldn't get space by ID!")
-		os.Exit(0)
-	}
-
-	if resp.Status() != http.StatusOK {
-		request.ProcessUnexpectedResponse(resp)
-	}
-
-	var space types.SpaceDetailed
-	err := json.Unmarshal(resp.Body(), &space)
-	if err != nil {
-		fmt.Println("Error unmarshalling space response!")
-		os.Exit(0)
-	}
-
-	return &space
-}
-
-func GetWorkflows(projectID, spaceID uuid.UUID, search string, library bool) []types.Workflow {
-	urlReq := "workflow/"
-	if library {
-		urlReq = "library/" + urlReq
-	}
-	urlReq += "?page_size=" + strconv.Itoa(math.MaxInt)
-	if !library {
-		urlReq += "&vault=" + util.GetVault().String()
-	}
-
-	if search != "" {
-		urlReq += "&search=" + url.QueryEscape(search)
-	}
-
-	if projectID != uuid.Nil {
-		urlReq += "&project=" + projectID.String()
-	} else if spaceID != uuid.Nil {
-		urlReq += "&space=" + spaceID.String()
-	}
-
-	resp := request.Trickest.Get().DoF(urlReq)
-	if resp == nil {
-		fmt.Println("Error: Couldn't get workflows!")
-		os.Exit(0)
-	}
-
-	if resp.Status() != http.StatusOK {
-		request.ProcessUnexpectedResponse(resp)
-	}
-
-	var workflows types.Workflows
-	err := json.Unmarshal(resp.Body(), &workflows)
-	if err != nil {
-		fmt.Println("Error: Couldn't unmarshal workflows response!")
-		os.Exit(0)
-	}
-
-	return workflows.Results
-}
-
-func GetWorkflowByID(id uuid.UUID) *types.Workflow {
-	resp := request.Trickest.Get().DoF("workflow/%s/", id.String())
-	if resp == nil {
-		fmt.Println("Error: Couldn't get workflow by ID!")
-		os.Exit(0)
-	}
-
-	if resp.Status() != http.StatusOK {
-		request.ProcessUnexpectedResponse(resp)
-	}
-
-	var workflow types.Workflow
-	err := json.Unmarshal(resp.Body(), &workflow)
-	if err != nil {
-		fmt.Println("Error: Couldn't unmarshal workflow response!")
-		os.Exit(0)
-	}
-
-	return &workflow
-}
-
-func ResolveObjectPath(path string, silent bool, isProject bool) (*types.SpaceDetailed, *types.Project, *types.Workflow, bool) {
-	pathSplit := strings.Split(strings.Trim(path, "/"), "/")
-	if len(pathSplit) > 3 {
-		if !silent {
-			fmt.Println("Invalid object path!")
-		}
-		return nil, nil, nil, false
-	}
-	space := GetSpaceByName(pathSplit[0])
-	if space == nil {
-		if !silent {
-			fmt.Println("Couldn't find space named " + pathSplit[0] + "!")
-		}
-		return nil, nil, nil, false
-	}
-
-	if len(pathSplit) == 1 {
-		return space, nil, nil, true
-	}
-
-	// Space and workflow with no project
-	var projectName string
-	var workflowName string
-	if len(pathSplit) == 2 {
-		if isProject {
-			projectName = pathSplit[1]
-			workflowName = ""
-		} else {
-			projectName = ""
-			workflowName = pathSplit[1]
-		}
-	} else {
-		projectName = pathSplit[1]
-		workflowName = pathSplit[2]
-	}
-
-	var project *types.Project
-	if space.Projects != nil && len(space.Projects) > 0 {
-		for _, proj := range space.Projects {
-			if proj.Name == projectName {
-				project = &proj
-				project.Workflows = GetWorkflows(project.ID, uuid.Nil, "", false)
-				break
-			}
-		}
-	}
-
-	var workflow *types.Workflow
-	if space.Workflows != nil && len(space.Workflows) > 0 {
-		for _, wf := range space.Workflows {
-			if wf.Name == workflowName {
-				workflow = &wf
-				break
-			}
-		}
-	}
-
-	if len(pathSplit) == 2 {
-		if project != nil || workflow != nil {
-			return space, project, workflow, true
-		}
-		if workflow != nil {
-			return space, nil, workflow, true
-		}
-		if !silent {
-			fmt.Println("Couldn't find project or workflow named " + pathSplit[1] + " inside " +
-				pathSplit[0] + " space!")
-		}
-		return space, nil, nil, false
-	}
-
-	if project != nil && project.Workflows != nil && len(project.Workflows) > 0 {
-		for _, wf := range project.Workflows {
-			if wf.Name == pathSplit[2] {
-				fullWorkflow := GetWorkflowByID(wf.ID)
-				return space, project, fullWorkflow, true
-			}
-		}
-	} else {
-		if !silent {
-			fmt.Println("No workflows found in " + pathSplit[0] + "/" + pathSplit[1])
-		}
-		return space, project, nil, false
-	}
-
-	if !silent {
-		fmt.Println("Couldn't find workflow named " + pathSplit[2] + " in " + pathSplit[0] + "/" + pathSplit[1] + "/")
-	}
-	return space, project, nil, false
 }
 
 func GetTools(pageSize int, search string, name string) []types.Tool {

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/trickest/trickest-cli/client/request"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
@@ -30,7 +31,7 @@ var ListCmd = &cobra.Command{
 		space, project, workflow, found := util.GetObjects(args)
 
 		if !found {
-			fmt.Println("Error: Workflow not found")
+			fmt.Println("Error: Not found")
 			return
 		}
 
@@ -45,6 +46,7 @@ var ListCmd = &cobra.Command{
 			}
 			printWorkflow(*workflow, jsonOutput)
 		} else if project != nil {
+			project.Workflows = util.GetWorkflows(project.ID, uuid.Nil, "", false)
 			printProject(*project, jsonOutput)
 		} else if space != nil {
 			printSpaceDetailed(*space)

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/trickest/trickest-cli/client/request"
-	"github.com/trickest/trickest-cli/cmd/list"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
 
@@ -62,6 +61,11 @@ The YAML config file should be formatted like:
       - bar
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		_, _, workflow, found := util.GetObjects(args)
+		if !found {
+			return
+		}
+
 		nodes := make(map[string]NodeInfo, 0)
 		if nodesFlag != "" {
 			for _, node := range strings.Split(nodesFlag, ",") {
@@ -73,30 +77,6 @@ The YAML config file should be formatted like:
 		if filesFlag != "" {
 			for _, file := range strings.Split(filesFlag, ",") {
 				files = append(files, file)
-			}
-		}
-
-		path := util.FormatPath()
-		if path == "" {
-			if len(args) == 0 {
-				fmt.Println("Workflow path must be specified!")
-				return
-			}
-			path = strings.Trim(args[0], "/")
-			if len(args) > 1 {
-				for i := 1; i < len(args); i++ {
-					nodes[strings.ReplaceAll(args[i], "/", "-")] = NodeInfo{ToFetch: true, Found: false}
-				}
-			}
-		} else {
-			if util.WorkflowName == "" {
-				fmt.Println("Workflow must be specified!")
-				return
-			}
-			if len(args) > 0 {
-				for i := 0; i < len(args); i++ {
-					nodes[strings.ReplaceAll(args[i], "/", "-")] = NodeInfo{ToFetch: true, Found: false}
-				}
 			}
 		}
 
@@ -123,11 +103,6 @@ The YAML config file should be formatted like:
 			for _, node := range conf.Outputs {
 				nodes[strings.ReplaceAll(node, "/", "-")] = NodeInfo{ToFetch: true, Found: false}
 			}
-		}
-
-		_, _, workflow, found := list.ResolveObjectPath(path, false, false)
-		if !found {
-			return
 		}
 
 		runs := make([]types.Run, 0)
@@ -163,6 +138,7 @@ The YAML config file should be formatted like:
 			return
 		}
 
+		path := util.FormatPath()
 		if outputDir != "" {
 			path = outputDir
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&util.SpaceName, "space", "", "Space name")
 	RootCmd.PersistentFlags().StringVar(&util.ProjectName, "project", "", "Project name")
 	RootCmd.PersistentFlags().StringVar(&util.WorkflowName, "workflow", "", "Workflow name")
+	RootCmd.PersistentFlags().StringVar(&util.URL, "url", "", "URL for referencing a workflow, project, or space")
 	RootCmd.PersistentFlags().StringVar(&util.Cfg.Dependency, "node-dependency", "", "This flag doesn't affect the execution logic of the CLI in any way and is intended for controlling node execution order on the Trickest platform only.")
 
 	cobra.OnInitialize(util.CreateRequest, initVaultID)

--- a/types/list.go
+++ b/types/list.go
@@ -49,7 +49,7 @@ type Project struct {
 	CreatedDate   time.Time  `json:"created_date"`
 	ModifiedDate  time.Time  `json:"modified_date"`
 	Author        string     `json:"author"`
-	Workflows     []Workflow `json:"workflow,omitempty"`
+	Workflows     []Workflow `json:"workflows,omitempty"`
 }
 
 type Workflows struct {

--- a/util/util.go
+++ b/util/util.go
@@ -104,10 +104,6 @@ func GetMe() *types.User {
 }
 
 func GetFleetInfo() *types.Fleet {
-	fleet := GetFleetInfoLegacy()
-	if fleet != nil {
-		return fleet
-	}
 	resp := request.Trickest.Get().DoF("fleet/?vault=%s", GetVault())
 	if resp == nil || resp.Status() != http.StatusOK {
 		request.ProcessUnexpectedResponse(resp)
@@ -125,21 +121,6 @@ func GetFleetInfo() *types.Fleet {
 	}
 
 	return &fleets.Results[0]
-}
-
-func GetFleetInfoLegacy() *types.Fleet {
-	resp := request.Trickest.Get().DoF("fleet/%s", GetVault())
-	if resp == nil || resp.Status() != http.StatusOK {
-		return nil
-	}
-
-	var fleet types.Fleet
-	err := json.Unmarshal(resp.Body(), &fleet)
-	if err != nil {
-		return nil
-	}
-
-	return &fleet
 }
 
 func GetSpaces(name string) []types.Space {


### PR DESCRIPTION
The `--url` flag is now available as a direct alternative to the `--space`, `--project`, and `--workflow` flags, applicable across all commands.