### PR TITLE
Multiple bug fixes and a light refactor to workflow output download

### DIFF
--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -987,8 +987,8 @@ func prepareForExec(objectPath string) *types.WorkflowVersionDetailed {
 	var primitiveNodes map[string]*types.PrimitiveNode
 	projectCreated := false
 
-	space, project, workflow, _ := util.ResolveObjectPath(objectPath, false)
-	if workflow == nil {
+	space, project, workflow, _ := util.ResolveObjectPath(objectPath, true)
+	if util.URL != "" {
 		space, project, workflow, _ = util.ResolveObjectURL(util.URL)
 	}
 

--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -238,7 +238,7 @@ func readWorkflowYAMLandCreateVersion(fileName string, workflowName string, obje
 		workflowName = wf.Name
 	}
 
-	space, project, workflow, _ := util.ResolveObjectPath(objectPath, true, false)
+	space, project, workflow, _ := util.ResolveObjectPath(objectPath, true)
 	if space == nil {
 		fmt.Println("Space " + strings.Split(objectPath, "/")[0] + " doesn't exist!")
 		os.Exit(0)
@@ -987,7 +987,7 @@ func prepareForExec(objectPath string) *types.WorkflowVersionDetailed {
 	var primitiveNodes map[string]*types.PrimitiveNode
 	projectCreated := false
 
-	space, project, workflow, _ := util.ResolveObjectPath(objectPath, false, false)
+	space, project, workflow, _ := util.ResolveObjectPath(objectPath, false)
 	if workflow == nil {
 		space, project, workflow, _ = util.ResolveObjectURL(util.URL)
 	}

--- a/cmd/execute/watch.go
+++ b/cmd/execute/watch.go
@@ -125,9 +125,9 @@ func WatchRun(runID uuid.UUID, downloadPath string, nodesToDownload map[string]o
 			}
 			if downloadAllNodes {
 				// DownloadRunOutputs downloads all outputs if no nodes were specified
-				output.DownloadRunOutput(run, nil, nil, nil, downloadPath)
+				output.DownloadRunOutput(run, nil, nil, downloadPath)
 			} else if len(nodesToDownload) > 0 {
-				output.DownloadRunOutput(run, nodesToDownload, filesToDownload, nil, downloadPath)
+				output.DownloadRunOutput(run, nodesToDownload, filesToDownload, downloadPath)
 			}
 			mutex.Unlock()
 			return

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -139,11 +139,6 @@ The YAML config file should be formatted like:
 			runs = append(runs, runs...)
 		}
 
-		version := GetWorkflowVersionByID(*runs[0].WorkflowVersionInfo, uuid.Nil)
-		if version == nil {
-			return
-		}
-
 		path := util.FormatPath()
 		if outputDir != "" {
 			path = outputDir
@@ -152,7 +147,7 @@ The YAML config file should be formatted like:
 			if run.Status == "SCHEDULED" {
 				continue
 			}
-			DownloadRunOutput(&run, nodes, files, version, path)
+			DownloadRunOutput(&run, nodes, files, path)
 		}
 	},
 }
@@ -167,16 +162,14 @@ func init() {
 	OutputCmd.Flags().StringVar(&filesFlag, "files", "", "A comma-separated list of file names that should be downloaded from the selected node")
 }
 
-func DownloadRunOutput(run *types.Run, nodes map[string]NodeInfo, files []string, version *types.WorkflowVersionDetailed, destinationPath string) {
+func DownloadRunOutput(run *types.Run, nodes map[string]NodeInfo, files []string, destinationPath string) {
 	if run.Status != "COMPLETED" && run.Status != "STOPPED" && run.Status != "FAILED" {
 		fmt.Println("The workflow run hasn't been completed yet!")
 		fmt.Println("Run ID: " + run.ID.String() + "   Status: " + run.Status)
 		return
 	}
 
-	if version == nil {
-		version = GetWorkflowVersionByID(*run.WorkflowVersionInfo, uuid.Nil)
-	}
+	version := GetWorkflowVersionByID(*run.WorkflowVersionInfo, uuid.Nil)
 
 	subJobs := getSubJobs(*run.ID)
 	labels := make(map[string]bool)
@@ -268,7 +261,7 @@ func DownloadRunOutput(run *types.Run, nodes map[string]NodeInfo, files []string
 			}
 		}
 		if noneFound {
-			fmt.Println("Couldn't find any nodes that match given name(s)!")
+			fmt.Printf("No completed node outputs matching your query were found in the \"%s\" run.", run.StartedDate.Format(layout))
 		} else {
 			for nodeName, nodeInfo := range nodes {
 				if !nodeInfo.Found {


### PR DESCRIPTION
- Fix a bug where project listing didn't work when no full path was specified.
- Recheck the workflow version when downloading multiple runs' outputs to handle cases where the workflow version changed.
- Add better handling for `--url` inputs.
