### PR TITLE
Include machine IP addresses in the JSON output of the get command

### DIFF
--- a/cmd/execute/watch.go
+++ b/cmd/execute/watch.go
@@ -73,9 +73,7 @@ func WatchRun(runID uuid.UUID, downloadPath string, nodesToDownload map[string]o
 		out := ""
 		out += fmt.Sprintf(fmtStr, "Name:", run.WorkflowName)
 		out += fmt.Sprintf(fmtStr, "Status:", strings.ToLower(run.Status))
-		availableMachines := GetAvailableMachines(fleetName)
-		out += fmt.Sprintf(fmtStr, "Machines:", FormatMachines(*machines, true)+
-			" (currently available: "+FormatMachines(availableMachines, true)+")")
+		out += fmt.Sprintf(fmtStr, "Machines:", FormatMachines(*machines, true))
 		out += fmt.Sprintf(fmtStr, "Created:", run.CreatedDate.In(time.Local).Format(time.RFC1123)+
 			" ("+util.FormatDuration(time.Since(run.CreatedDate))+" ago)")
 		if run.Status != "PENDING" {

--- a/types/list.go
+++ b/types/list.go
@@ -124,6 +124,7 @@ type Run struct {
 	Finished            bool       `json:"finished,omitempty"`
 	Author              string     `json:"author,omitempty"`
 	Fleet               *uuid.UUID `json:"fleet,omitempty"`
+	IPAddresses         []string   `json:"ip_addresses,omitempty"`
 }
 
 type Machines struct {


### PR DESCRIPTION
```
$ trickest get --space "Playground" --workflow "My Workflow" --json

{
  ...
  "ip_addresses": [
    "1.2.3.4",
    "5.6.7.8",
    "9.10.11.12",
    ...
  ]
}
```