### PR TITLE
Update list.go

### DIFF
--- a/types/list.go
+++ b/types/list.go
@@ -216,12 +216,12 @@ type ToolInput struct {
 }
 
 type Categories struct {
-	Next     any        `json:"next"`
-	Previous any        `json:"previous"`
-	Page     int        `json:"page"`
-	Last     int        `json:"last"`
-	Count    int        `json:"count"`
-	Results  []Category `json:"results"`
+    Next     string     `json:"next"`
+    Previous string     `json:"previous"`
+    Page     int        `json:"page"`
+    Last     int        `json:"last"`
+    Count    int        `json:"count"`
+    Results  []Category `json:"results"`
 }
 
 type Category struct {


### PR DESCRIPTION
The error you're encountering, undefined: any, indicates that the type any is not defined in Go. It seems you have mistakenly used any as a type in your struct definition. Go doesn't have a built-in type named any; instead, you should use a specific type or define a custom type if necessary.

In your Categories struct, you have used any as the type for the Next and Previous fields. These fields are likely intended to hold some specific type of data, such as a string or a pointer to another struct.

Replace any with the appropriate type, such as string if these fields are URLs or identifiers, or with the actual type if you have more specific requirements.

Here's how you can correct your Categories struct:

```
type Categories struct {
    Next     string     `json:"next"`
    Previous string     `json:"previous"`
    Page     int        `json:"page"`
    Last     int        `json:"last"`
    Count    int        `json:"count"`
    Results  []Category `json:"results"`
}
```

Once you've made this change, try rebuilding your Docker image to see if the error persists.