### PR TITLE
Add files list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,19 @@ trickest files delete --file delete_me.txt
 | --file               | string  | /       | File or files (comma-separated)                                     |
 
 
+#### List files
+Use the **list** command with the optional **--query** flag to list or search for files
+
+```
+trickest files list
+```
+
+| Flag                 | Type    | Default  | Description                                                         |
+|----------------------|---------|----------|---------------------------------------------------------------------|
+| --query              | string  | /        | Filter listed files using the specified search query                |
+| --json               | boolean | false    | Display output in JSON format                                       |
+
+
 ## Tools command
 Manage [private tools](https://trickest.com/docs/tutorials/private-tools/private-tools-library/)
 

--- a/cmd/files/filesCreate.go
+++ b/cmd/files/filesCreate.go
@@ -36,6 +36,9 @@ var filesCreateCmd = &cobra.Command{
 
 func init() {
 	FilesCmd.AddCommand(filesCreateCmd)
+
+	filesCreateCmd.Flags().StringVar(&Files, "file", "", "File or files (comma-separated)")
+	filesCreateCmd.MarkFlagRequired("file")
 }
 
 func createFile(filePath string) error {

--- a/cmd/files/filesDelete.go
+++ b/cmd/files/filesDelete.go
@@ -29,6 +29,9 @@ var filesDeleteCmd = &cobra.Command{
 
 func init() {
 	FilesCmd.AddCommand(filesDeleteCmd)
+
+	filesDeleteCmd.Flags().StringVar(&Files, "file", "", "File or files (comma-separated)")
+	filesDeleteCmd.MarkFlagRequired("file")
 }
 
 func deleteFile(fileName string) error {

--- a/cmd/files/filesGet.go
+++ b/cmd/files/filesGet.go
@@ -37,8 +37,9 @@ var filesGetCmd = &cobra.Command{
 func init() {
 	FilesCmd.AddCommand(filesGetCmd)
 
+	filesGetCmd.Flags().StringVar(&Files, "file", "", "File or files (comma-separated)")
+	filesGetCmd.MarkFlagRequired("file")
 	filesGetCmd.Flags().StringVar(&outputDir, "output-dir", ".", "Path to directory which should be used to store files")
-
 	filesGetCmd.Flags().BoolVar(&partialNameMatch, "partial-name-match", false, "Get all files with a partial name match")
 }
 

--- a/cmd/files/filesList.go
+++ b/cmd/files/filesList.go
@@ -1,0 +1,62 @@
+package files
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/trickest/trickest-cli/types"
+	"github.com/xlab/treeprint"
+)
+
+var (
+	searchQuery string
+	jsonOutput  bool
+)
+
+// filesListCmd represents the filesGet command
+var filesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List files in the Trickest file storage",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		files, err := getMetadata(searchQuery)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+		} else {
+			printFiles(files, jsonOutput)
+		}
+	},
+}
+
+func init() {
+	FilesCmd.AddCommand(filesListCmd)
+
+	filesListCmd.Flags().StringVar(&searchQuery, "query", "", "Filter listed files using the specified search query")
+	filesListCmd.Flags().BoolVar(&jsonOutput, "json", false, "Display output in JSON format")
+}
+
+func printFiles(files []types.File, jsonOutput bool) {
+	var output string
+
+	if jsonOutput {
+		data, err := json.Marshal(files)
+		if err != nil {
+			fmt.Println("Error marshalling response data")
+			return
+		}
+		output = string(data)
+	} else {
+		tree := treeprint.New()
+		tree.SetValue("Files")
+		for _, file := range files {
+			fileSubBranch := tree.AddBranch("\U0001f4c4 " + file.Name)                             //📄
+			fileSubBranch.AddNode("\U0001f522 " + file.PrettySize)                                 //🔢
+			fileSubBranch.AddNode("\U0001f4c5 " + file.ModifiedDate.Format("2006-01-02 15:04:05")) //📅
+		}
+
+		output = tree.String()
+	}
+
+	fmt.Println(output)
+}

--- a/types/files.go
+++ b/types/files.go
@@ -16,9 +16,6 @@ type Files struct {
 type File struct {
 	ID           string    `json:"id"`
 	Name         string    `json:"name"`
-	Vault        string    `json:"vault"`
-	TweID        string    `json:"twe_id"`
-	ArtifactID   string    `json:"artifact_id"`
 	Size         int       `json:"size"`
 	PrettySize   string    `json:"pretty_size"`
 	ModifiedDate time.Time `json:"modified_date"`


### PR DESCRIPTION
The command supports listing all files by default or using an optional --query flag for searching. Each file entry includes the file name, size, and last modified date.

```
trickest files list

Files
├── 📄 hostnames.txt
│   ├── 🔢 13.1MB
│   └── 📅 2024-07-01 14:29:31
├── 📄 open-ports.json
│   ├── 🔢 102.5MB
│   └── 📅 2024-07-01 16:39:31
└── 📄 web-servers.json
    ├── 🔢 308.9MB
    └── 📅 2024-07-01 18:49:31
```


```
trickest files list --query ".json"

Files
├── 📄 open-ports.json
│   ├── 🔢 102.5MB
│   └── 📅 2024-07-01 16:39:31
└── 📄 web-servers.json
    ├── 🔢 308.9MB
    └── 📅 2024-07-01 18:49:31
```

```
trickest files list --query ".json" --json | jq

[
  {
    "id": "f3094b3d-ef43-4195-8614-e160525968a6",
    "name": "open-ports.json",
    "size": 107374182,
    "pretty_size": "102.5MB",
    "modified_date": "2024-07-01T16:39:31Z"
  },
  {
    "id": "6f28ba6c-c5b0-473b-9e34-c76825419286",
    "name": "web-servers.json",
    "size": 323697680,
    "pretty_size": "308.9MB",
    "modified_date": "2024-07-01T18:49:31Z"
  }
]
```
