### PR TITLE
Output command improvements

### DIFF
--- a/cmd/execute/config.go
+++ b/cmd/execute/config.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/trickest/trickest-cli/cmd/output"
 	"github.com/trickest/trickest-cli/types"
 
 	"gopkg.in/yaml.v3"
@@ -491,8 +490,8 @@ func addPrimitiveNodeFromConfig(wfVersion *types.WorkflowVersionDetailed, newPri
 	return updateNeeded
 }
 
-func readConfigOutputs(config *map[string]interface{}) map[string]output.NodeInfo {
-	downloadNodes := make(map[string]output.NodeInfo)
+func readConfigOutputs(config *map[string]interface{}) []string {
+	var downloadNodes []string
 	if outputs, exists := (*config)["outputs"]; exists && outputs != nil {
 		outputsList, isList := outputs.([]interface{})
 		if !isList {
@@ -502,7 +501,7 @@ func readConfigOutputs(config *map[string]interface{}) map[string]output.NodeInf
 		for _, node := range outputsList {
 			nodeName, ok := node.(string)
 			if ok {
-				downloadNodes[nodeName] = output.NodeInfo{ToFetch: true, Found: false}
+				downloadNodes = append(downloadNodes, nodeName)
 			} else {
 				fmt.Print("Invalid output node name: ")
 				fmt.Println(node)

--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/trickest/trickest-cli/cmd/create"
 	"github.com/trickest/trickest-cli/cmd/list"
-	"github.com/trickest/trickest-cli/cmd/output"
 	"github.com/trickest/trickest-cli/types"
 	"github.com/trickest/trickest-cli/util"
 
@@ -31,7 +30,7 @@ var (
 	showParams           bool
 	executionMachines    types.Machines
 	fleet                *types.Fleet
-	nodesToDownload      = make(map[string]output.NodeInfo, 0)
+	nodesToDownload      []string
 	allNodes             map[string]*types.TreeNode
 	roots                []*types.TreeNode
 	workflowYAML         string

--- a/cmd/execute/helpers.go
+++ b/cmd/execute/helpers.go
@@ -131,7 +131,7 @@ func createRun(versionID, fleetID uuid.UUID, watch bool, outputNodes []string, o
 
 	if len(outputNodes) > 0 || downloadAllNodes {
 		for _, nodeName := range outputNodes {
-			nodesToDownload[nodeName] = output.NodeInfo{ToFetch: true, Found: false}
+			nodesToDownload = append(nodesToDownload, nodeName)
 		}
 		watch = true
 	}

--- a/cmd/execute/watch.go
+++ b/cmd/execute/watch.go
@@ -22,7 +22,7 @@ import (
 	"github.com/xlab/treeprint"
 )
 
-func WatchRun(runID uuid.UUID, downloadPath string, nodesToDownload map[string]output.NodeInfo, filesToDownload []string, timestampOnly bool, machines *types.Machines, showParameters bool) {
+func WatchRun(runID uuid.UUID, downloadPath string, nodesToDownload []string, filesToDownload []string, timestampOnly bool, machines *types.Machines, showParameters bool) {
 	const fmtStr = "%-12s %v\n"
 	writer := uilive.New()
 	writer.Start()

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -79,7 +79,7 @@ var GetCmd = &cobra.Command{
 				output := string(data)
 				fmt.Println(output)
 			} else {
-				execute.WatchRun(*run.ID, "", map[string]output.NodeInfo{}, []string{}, !watch, &runs[0].Machines, showNodeParams)
+				execute.WatchRun(*run.ID, "", []string{}, []string{}, !watch, &runs[0].Machines, showNodeParams)
 			}
 			return
 		} else {

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -62,6 +62,11 @@ The YAML config file should be formatted like:
 			for _, node := range strings.Split(nodesFlag, ",") {
 				nodes = append(nodes, strings.ReplaceAll(node, "/", "-"))
 			}
+		} else if util.URL != "" {
+			node, err := util.GetNodeIDFromWorkflowURL(util.URL)
+			if err == nil {
+				nodes = append(nodes, node)
+			}
 		}
 
 		var files []string

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -188,13 +188,6 @@ func DownloadRunOutput(run *types.Run, nodes []string, files []string, destinati
 
 	if len(nodes) == 0 {
 		for _, subJob := range subJobs {
-			for subJob.OutputsStatus == "SAVING" || subJob.OutputsStatus == "WAITING" {
-				updatedSubJob := getSubJobByID(subJob.ID)
-				if updatedSubJob == nil {
-					os.Exit(0)
-				}
-				subJob.OutputsStatus = updatedSubJob.OutputsStatus
-			}
 			isModule := false
 			if (version.Data.Nodes[subJob.Name]).Type == "WORKFLOW" {
 				isModule = true

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -127,8 +127,8 @@ func init() {
 }
 
 func DownloadRunOutput(run *types.Run, nodes []string, files []string, destinationPath string) {
-	if run.Status != "COMPLETED" && run.Status != "STOPPED" && run.Status != "STOPPING" && run.Status != "FAILED" {
-		fmt.Println("The workflow run hasn't been completed yet!")
+	if run.Status == "PENDING" || run.Status != "SUBMITTED" {
+		fmt.Println("The workflow run hasn't started yet!")
 		fmt.Println("Run ID: " + run.ID.String() + "   Status: " + run.Status)
 		return
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -433,6 +433,14 @@ func resolveWorkflowURL(pathSegments []string) (*types.SpaceDetailed, *types.Pro
 }
 
 func GetRunIDFromWorkflowURL(workflowURL string) (string, error) {
+	return geParameterValueFromURL(workflowURL, "run")
+}
+
+func GetNodeIDFromWorkflowURL(workflowURL string) (string, error) {
+	return geParameterValueFromURL(workflowURL, "node")
+}
+
+func geParameterValueFromURL(workflowURL string, parameter string) (string, error) {
 	u, err := url.Parse(workflowURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL: %w", err)
@@ -443,16 +451,16 @@ func GetRunIDFromWorkflowURL(workflowURL string) (string, error) {
 		return "", fmt.Errorf("invalid URL query: %w", err)
 	}
 
-	runIDs, found := queryParams["run"]
+	paramValues, found := queryParams[parameter]
 	if !found {
-		return "", fmt.Errorf("no run parameter in the URL")
+		return "", fmt.Errorf("no %s parameter in the URL", parameter)
 	}
 
-	if len(runIDs) != 1 {
-		return "", fmt.Errorf("invalid number of run parameters in the URL")
+	if len(paramValues) != 1 {
+		return "", fmt.Errorf("invalid number of %s parameters in the URL: %d", parameter, len(paramValues))
 	}
 
-	return runIDs[0], nil
+	return paramValues[0], nil
 }
 
 // GetObjects handles different input scenarios for retrieving platform objects.


### PR DESCRIPTION
- Improve error handling and logging for sub-job output downloads
- Infer the node to download from using the workflow URL, unless explicitly set via the `--nodes` flag
- Add support for concurrent downloads of taskgroup outputs
- Reduce delay before initiating taskgroup output downloads
- Refactor code and remove deprecated logic
- Enable output downloads for all run statuses, excluding "pending" and "submitted" only
- Support downloads of partially executed taskgroups
- Map taskgroup output folders to platform task indices