### PR TITLE
Downgrade errors to warnings when some downloads fail but at least one succeeds, and improve error logging

### DIFF
--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -295,7 +295,11 @@ func run(cfg *Config) error {
 		if err != nil {
 			return fmt.Errorf("failed to get run: %w", err)
 		}
-		actions.DownloadRunOutput(client, run, cfg.NodesToDownload, []string{}, cfg.OutputDirectory)
+		results, err := actions.DownloadRunOutput(client, run, cfg.NodesToDownload, []string{}, cfg.OutputDirectory)
+		if err != nil {
+			return fmt.Errorf("failed to download run outputs: %w", err)
+		}
+		actions.PrintDownloadResults(results)
 	}
 
 	return nil

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -84,9 +84,11 @@ func run(cfg *Config) error {
 	path := cfg.GetOutputPath()
 
 	for _, run := range runs {
-		if err := actions.DownloadRunOutput(client, &run, nodes, files, path); err != nil {
+		results, err := actions.DownloadRunOutput(client, &run, nodes, files, path)
+		if err != nil {
 			return fmt.Errorf("failed to download run output: %w", err)
 		}
+		actions.PrintDownloadResults(results)
 	}
 	return nil
 }


### PR DESCRIPTION
When all downloads succeed, the following message is printed:
```
Successfully downloaded outputs for 6 sub-jobs
```

---

If at least one download fails, a warning is printed for each failed node, for example:
```
Warning: Failed to download output for node "<node-label>": <error-details>
```
and a summary is printed indicating the number of successful and failed downloads
```
Download completed with X successful and Y failed downloads
```