### PR TITLE
Improve mass output downloads

### DIFF
--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -295,11 +295,11 @@ func run(cfg *Config) error {
 		if err != nil {
 			return fmt.Errorf("failed to get run: %w", err)
 		}
-		results, err := actions.DownloadRunOutput(client, run, cfg.NodesToDownload, []string{}, cfg.OutputDirectory)
+		results, runDir, err := actions.DownloadRunOutput(client, run, cfg.NodesToDownload, []string{}, cfg.OutputDirectory)
 		if err != nil {
 			return fmt.Errorf("failed to download run outputs: %w", err)
 		}
-		actions.PrintDownloadResults(results)
+		actions.PrintDownloadResults(results, *run.ID, runDir)
 	}
 
 	return nil

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -124,9 +124,12 @@ func run(cfg *Config) error {
 		}
 		subJobs = trickest.LabelSubJobs(subJobs, *version)
 
-		matchingSubJobs, err := trickest.FilterSubJobs(subJobs, cfg.Nodes)
-		if err != nil {
-			return fmt.Errorf("no running nodes matching your query were found in the run %s: %w", run.ID.String(), err)
+		matchingSubJobs, unmatchedNodes := trickest.FilterSubJobs(subJobs, cfg.Nodes)
+		if len(matchingSubJobs) == 0 {
+			return fmt.Errorf("no running nodes matching your query %q were found in the run %s", strings.Join(cfg.Nodes, ","), run.ID.String())
+		}
+		if len(unmatchedNodes) > 0 {
+			fmt.Fprintf(os.Stderr, "Warning: The following nodes were not found in run %s: %s. Proceeding with the remaining nodes\n", run.ID.String(), strings.Join(unmatchedNodes, ","))
 		}
 
 		for _, subJob := range matchingSubJobs {

--- a/pkg/actions/output.go
+++ b/pkg/actions/output.go
@@ -54,6 +54,13 @@ func DownloadRunOutput(client *trickest.Client, run *trickest.Run, nodes []strin
 		return nil, fmt.Errorf("failed to get subjobs for run %s: %w", run.ID.String(), err)
 	}
 
+	// If the run was retrieved through the GetRuns() method, the WorkflowVersionInfo field will be nil
+	if run.WorkflowVersionInfo == nil {
+		run, err = client.GetRun(ctx, *run.ID)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get run details for run %s: %w", run.ID.String(), err)
+		}
+	}
 	version, err := client.GetWorkflowVersion(ctx, *run.WorkflowVersionInfo)
 	if err != nil {
 		return nil, fmt.Errorf("could not get workflow version for run %s: %w", run.ID.String(), err)

--- a/pkg/actions/output.go
+++ b/pkg/actions/output.go
@@ -19,7 +19,7 @@ type DownloadResult struct {
 	Error      error
 }
 
-func PrintDownloadResults(results []DownloadResult) {
+func PrintDownloadResults(results []DownloadResult, runID uuid.UUID, destinationPath string) {
 	successCount := 0
 	failureCount := 0
 	for _, result := range results {
@@ -28,17 +28,17 @@ func PrintDownloadResults(results []DownloadResult) {
 		} else {
 			failureCount++
 			if result.FileName != "" {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to download file %q for node %q: %v\n", result.FileName, result.SubJobName, result.Error)
+				fmt.Fprintf(os.Stderr, "Warning: Failed to download file %q for node %q in run %s: %v\n", result.FileName, result.SubJobName, runID.String(), result.Error)
 			} else {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to download output for node %q: %v\n", result.SubJobName, result.Error)
+				fmt.Fprintf(os.Stderr, "Warning: Failed to download output for node %q in run %s: %v\n", result.SubJobName, runID.String(), result.Error)
 			}
 		}
 	}
 
 	if failureCount > 0 {
-		fmt.Fprintf(os.Stderr, "Download completed with %d successful and %d failed downloads\n", successCount, failureCount)
+		fmt.Fprintf(os.Stderr, "Download completed with %d successful and %d failed downloads for run %s into %q\n", successCount, failureCount, runID.String(), destinationPath+"/")
 	} else if successCount > 0 {
-		fmt.Printf("Successfully downloaded outputs for %d sub-jobs\n", successCount)
+		fmt.Printf("Successfully downloaded %d outputs from run %s into %q\n", successCount, runID.String(), destinationPath+"/")
 	}
 }
 

--- a/pkg/config/workflowrunspec.go
+++ b/pkg/config/workflowrunspec.go
@@ -49,7 +49,7 @@ func (s WorkflowRunSpec) GetRuns(ctx context.Context, client *trickest.Client) (
 	}
 
 	limit := 0 // 0 means get all runs
-	if s.NumberOfRuns > 0 {
+	if s.NumberOfRuns > 0 && !s.AllRuns {
 		limit = s.NumberOfRuns
 	}
 


### PR DESCRIPTION
- Gracefully skip failed run downloads instead of aborting on the first error
- Support partial matches for node queries passed via `--nodes`
- Enhance download status messages with destination path and run ID
- Fix bug causing failed downloads when a simplified run object lacks the version info